### PR TITLE
FEAT: Componente de Agenda por Espaço/Iniciativa

### DIFF
--- a/components/search-list-agenda/script.js
+++ b/components/search-list-agenda/script.js
@@ -1,0 +1,102 @@
+app.component('search-list-agenda', {
+    template: $TEMPLATES['search-list-agenda'],
+    
+    created() {
+        this.currentDate = null;
+        this.eventApi = new API('event');
+        this.spaceApi = new API('space');
+        this.fetchOccurrences();
+    },
+
+    data() {
+        return {
+            occurrences: [],
+            loading: false,
+            page: 1
+        }
+    },
+
+    watch: {
+        pseudoQuery: {
+            handler(){
+                clearTimeout(this.watchTimeout);
+                this.loading = true;
+                this.page = 1;
+
+                this.watchTimeout = setTimeout(() => {
+                    this.fetchOccurrences();
+                }, 500)
+            },
+            deep: true,
+        }
+    },
+
+    props: {
+        limit: {
+            type: Number,
+            default: 20,
+        },
+        select: {
+            type: String,
+            default: 'id,name,subTitle,files.avatar,seals,terms,classificacaoEtaria,singleUrl'
+        },
+        spaceSelect: {
+            type: String,
+            default: 'id,name,endereco,files.avatar,singleUrl'
+        },
+        pseudoQuery: {
+            type: Object,
+            required: true
+        }
+    },
+
+    methods: {
+        // http://localhost/api/event/findOccurrences?@from=2022-08-19&@to=2022-09-19&space:@select=id,name,shortDescription,endereco&@select=
+        async fetchOccurrences() {
+            const query = Utils.parsePseudoQuery(this.pseudoQuery);
+
+            this.loading = true;
+            // clearTimeout(this.timeout);
+            // this.timeout = setTimeout(() => {
+                
+            // }, 500)
+            if(query['@keyword']) {
+                query['event:@keyword'] = query['@keyword'];
+                delete query['@keyword'];
+            }
+            query['event:@select'] = this.select;
+            query['space:@select'] = this.spaceSelect;
+            query['@limit'] = this.limit;
+            query['@page'] = this.page;
+            
+            const occurrences = await this.eventApi.fetch('occurrences', query, {
+                raw: true,
+                rawProcessor: (rawData) => Utils.occurrenceRawProcessor(rawData, this.eventApi, this.spaceApi)
+            });
+            
+            const metadata = occurrences.metadata;
+
+            if(this.page === 1) {
+                this.occurrences = occurrences;
+            } else {
+                this.occurrences = this.occurrences.concat(occurrences);
+                this.occurrences.metadata = metadata;
+            }
+            this.loading = false;
+        },
+
+        loadMore() {
+            this.page++;
+            this.fetchOccurrences();
+        },
+
+        newDate(occurrence) {
+            if (this.currentDate?.date('long') != occurrence.starts.date('long')) {
+                this.currentDate = occurrence.starts;
+                return true;
+            } else {
+                return false;
+            }
+        }
+    },
+});

--- a/components/search-list-agenda/template.php
+++ b/components/search-list-agenda/template.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * @var MapasCulturais\App $app
+ * @var MapasCulturais\Themes\BaseV2\Theme $this
+ */
+
+use MapasCulturais\i;
+
+$this->import('
+    mc-loading
+    occurrence-card
+');
+?>
+
+<style>
+.search-list__cards > .grid-12 {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+    margin-top: 2rem;
+}
+
+.search-list__cards .col-4 {
+    flex: 0 0 calc(33.333% - 1rem);
+    box-sizing: border-box;
+}
+</style>
+
+<div class="grid-12 search-list">
+    <mc-loading :condition="loading && page === 1"></mc-loading>
+
+    <div v-if="!loading || page > 1" class="col-12 search-list__cards">
+        <div class="grid-12">
+            <div v-for="occurrence in occurrences" :key="occurrence._reccurrence_string" class="col-4">
+                <div v-if="newDate(occurrence)" class="search-list__cards--date">
+                    <div class="search-list__cards--date-info">
+                        <h2 v-if="occurrence.starts.isToday()" class="actual-date">
+                            <?= i::__('Hoje') ?>
+                            <label class="month"><?= i::__('{{occurrence.starts.month()}}') ?></label>
+                        </h2>
+                        <h2 v-else-if="occurrence.starts.isTomorrow()" class="actual-date">
+                            <?= i::__('Amanhã') ?>
+                            <label class="month"><?= i::__('{{occurrence.starts.month()}}') ?></label>
+                        </h2>
+                        <h2 v-else-if="occurrence.starts.isYesterday()" class="actual-date">
+                            <?= i::__('Ontem') ?>
+                            <label class="month"><?= i::__('{{occurrence.starts.month()}}') ?></label>
+                        </h2>
+                        <template v-else>
+                            <h2 class="actual-date">
+                                {{ occurrence.starts.day() }}
+                                <label class="month"><?= i::__('{{occurrence.starts.month()}}') ?></label>
+                            </h2>
+                        </template>
+                        <label class="weekend">{{ occurrence.starts.weekday() }}</label>
+                    </div>
+                    <div class="search-list__cards--date-line"></div>
+                </div>
+                <occurrence-card :occurrence="occurrence"></occurrence-card>
+            </div>
+        </div>
+    </div>
+</div>

--- a/components/search-list-agenda/texts.php
+++ b/components/search-list-agenda/texts.php
@@ -1,0 +1,5 @@
+<?php
+use MapasCulturais\i;
+
+return [    
+];

--- a/views/project/single.php
+++ b/views/project/single.php
@@ -27,9 +27,7 @@ $this->import('
     mc-share-links
     mc-tab
     mc-tabs
-    search
-    search-filter-event
-    search-list-event
+    search-list-agenda
 ');
 
 $label = $this->isRequestedEntityMine() ? i::__('Meus projetos') : i::__('Projetos');
@@ -158,11 +156,11 @@ if($children_id ){
         </mc-tab>
         <mc-tab icon="event" label="<?= i::_e('Agenda') ?>" slug="agenda">
             <div class="search__tabs--list">
-                <search-list-event 
+                <search-list-agenda 
                     :pseudo-query='<?= json_encode([
                         "event:project" => $entity->id,
-                        "@from" => date('Y-m-d'),
-                        "@to" => date('Y-m-d', strtotime("+30 days")),
+                        "@from" => date("Y-m-d"),
+                        "@to" => date("Y") . "-12-31"
                     ]) ?>'
                     select="id,name,subTitle,files.avatar,seals,terms,classificacaoEtaria,singleUrl,project"
                     space-select="id,name,endereco,files.avatar,singleUrl"

--- a/views/space/single.php
+++ b/views/space/single.php
@@ -25,9 +25,7 @@ $this->import('
     mc-tab
     mc-tabs
     opportunity-list
-    search
-    search-filter-event
-    search-list-event
+    search-list-agenda
 ');
 
 $this->breadcrumb = [
@@ -102,11 +100,11 @@ $this->breadcrumb = [
         </mc-tab>
         <mc-tab icon="event" label="<?= i::_e('Agenda') ?>" slug="agenda">
             <div class="search__tabs--list">
-                <search-list-event 
+                <search-list-agenda 
                     :pseudo-query='<?= json_encode([
                         "space:id" => $entity->id,
-                        "@from" => date('Y-m-d'),
-                        "@to" => date('Y-m-d', strtotime("+30 days")),
+                        "@from" => date("Y-m-d"),
+                        "@to" => date("Y") . "-12-31"
                     ]) ?>'
                     select="id,name,subTitle,files.avatar,seals,terms,classificacaoEtaria,singleUrl"
                     space-select="id,name,endereco,files.avatar,singleUrl"


### PR DESCRIPTION
## ✨ [PR] Componente de Agenda por Espaço/Iniciativa: Visualização em 3 colunas + filtro automático por vínculo

### 🎯 Objetivo

Este PR implementa parte da demanda de exibir a agenda de eventos diretamente nas páginas de Espaços e Iniciativas, filtrando apenas os eventos vinculados ao respectivo espaço ou iniciativa.

---

### ⚙️ Implementações

- ✅ Criação de um novo componente Vue+PHP chamado <search-list-agenda> no tema Funarte;
- ✅ Filtro automático de eventos com base na relação space:id = $entity->id;
- ✅ Layout em 3 colunas fixas, responsivo, utilizando flex e col-4, com espaçamento adequado;
- ✅ Exibição por data com cabeçalhos "Hoje", "Amanhã", etc., conforme já praticado na plataforma.
---

### 🧪 Testes realizados

- [x] Validação visual do layout em 3 colunas;
- [x] Teste com múltiplos eventos vinculados ao mesmo espaço (recorrentes e únicos);
- [x] Verificação do filtro por space:id;
- [x] Testes em resoluções diferentes (responsividade preservada);

---

### 📸 Capturas (antes/depois)

**Antes:**  
**A funcionalidade não existia!**

**Depois - Desktop:**  
![image](https://github.com/user-attachments/assets/f53007a9-038d-4a08-9689-1f87817fd635)
![image](https://github.com/user-attachments/assets/a5543aea-e660-449b-ae72-f2503cd48e33)

**Depois - Mobile:**  
![image](https://github.com/user-attachments/assets/33dfad09-d57a-47a2-b112-6c45d0be652c)
![image](https://github.com/user-attachments/assets/cc6bee9c-0dd7-4c27-adbe-0e6436e63530)


---

### 🚫 Observações

Conforme alinhado:

- A demanda foi feita em pair programming com a @laurapetrola;
- Este componente não exibe filtros visuais (como linguagem ou faixa etária), conforme escopo da demanda atual, tudo isso alinhado com o @lpirola;
- A nomenclatura search-list-agenda foi usada para evitar conflito com o componente original search-list-event;

---
