### PR TITLE
FIX: Correções de homologação da home

### DIFF
--- a/assets-src/sass/components/_home-circuits.scss
+++ b/assets-src/sass/components/_home-circuits.scss
@@ -19,7 +19,6 @@
       min-height: 466px;
       background-color: $white;
       max-width: size(1170);
-      padding-left: size(25);
       margin: 0 auto;
       gap:0 12rem;
     }
@@ -89,7 +88,7 @@
       .hero-circuits {
         flex-direction: column;
         text-align: left;
-        padding: 3rem 2.625rem;
+        padding: 60px 16px;
         justify-content: space-around;
         align-items: center;
       }

--- a/components/home-circuits/template.php
+++ b/components/home-circuits/template.php
@@ -17,9 +17,6 @@ $circuits_url = $app->view->asset('img/home/home-circuits/circuits.gif', false);
 $circuits_brasil_url = $app->view->asset('img/home/home-circuits/artBrasil.png', false);
 ?>
 
-<div class="custom-background">
-    <div class="divider-line"></div>
-</div>
 <section class="hero-circuits">
     <div class="hero-circuits--top">
         <div class="hero-circuits--text">
@@ -37,6 +34,3 @@ $circuits_brasil_url = $app->view->asset('img/home/home-circuits/artBrasil.png',
         <a href="<?= $app->createUrl("search","events")?>">Ver Circuitos Artísticos</a>
     </button>
 </section>
-<div class="custom-background">
-    <div class="divider-line"></div>
-</div>

--- a/components/home-entities/template.php
+++ b/components/home-entities/template.php
@@ -12,8 +12,7 @@ $entities = [
     'projects' => [
         'image' => 'img/cards/agenda_bg.png',
         'title' => 'Agenda',
-        'route' => 'search/agenda',
-        // TODO: ADICIONAR TELA DE AGENDA
+        'route' => 'search/events',
         'description' => 'Aqui você pode acompanhar as ações da Rede das Artes: apresentações artísticas, ações de pesquisa, reflexão, intercâmbios, criação, oficinas, cursos, entre outras. Uma agenda cultural que integra iniciativas artísticas de todo o Brasil.',
     ],
     'opportunities' => [
@@ -27,12 +26,6 @@ $entities = [
         'title' => 'Agentes',
         'route' => 'search/agents',
         'description' => 'Acesso a inúmeras possibilidades de conexão com a Rede das Artes. Aqui você encontra atividades com inscrições abertas, como convocatórias, oficinas, intercâmbios e residências artísticas, editais, eventos e demais oportunidades acessíveis. Você também pode criar e ofertar oportunidades para outros agentes da Rede.',
-    ],
-    'events' => [
-        'image' => 'img/cards/eventos_bg.png',
-        'title' => 'Eventos',
-        'route' => 'search/events',
-        'description' => 'Aqui você pode inscrever o seu evento e também se conectar com propostas curatoriais diversas, programações artísticas de abrangência local, interestadual e/ou internacional. São festivais, bienais, encontros, feiras, mostras, salões, fóruns que propõem apresentações artísticas, exibições públicas, ações de formação, articulação e difusão.',
     ],
     'spaces' => [
         'image' => 'img/cards/espacos_bg.png',

--- a/components/home-prosas-notices/script.js
+++ b/components/home-prosas-notices/script.js
@@ -1,18 +1,43 @@
 app.component('home-prosas-notices', {
     template: $TEMPLATES['home-prosas-notices'],
 
-    setup(props) {
-        // os textos estão localizados no arquivo texts.php deste componente 
-        const text = Utils.getTexts('home-prosas-notices');
-        const global = useGlobalState();
-        
-        // Adiciona os componentes que acessam a API do Prosas.
-        let script = document.createElement('script');
+    mounted() {
+        const script = document.createElement('script');
         script.type = 'text/javascript';
         script.src = 'https://cdn.prosas.com.br/front-sdk/prod/latest/webcomponents.bundle.js';
         document.body.appendChild(script);
 
-        return { text, global }
+        const replaceShadowLabel = () => {
+            const components = document.querySelectorAll('prosas-listagem-editais');
+
+            components.forEach(el => {
+                const shadow = el.shadowRoot;
+                if (shadow) {
+                    const paragraphs = shadow.querySelectorAll('p');
+                    paragraphs.forEach(p => {
+                        if (p.textContent.trim() === 'Desenvolvido por') {
+                            p.textContent = 'Seção exibida por';
+                        }
+                    });
+                }
+            });
+        };
+
+        const observer = new MutationObserver(() => replaceShadowLabel());
+        observer.observe(document.body, { childList: true, subtree: true });
+
+        const timeoutId = setTimeout(() => replaceShadowLabel(), 1000);
+
+        setTimeout(() => {
+            observer.disconnect();
+            clearTimeout(timeoutId);
+        }, 5000);
+    },
+
+    setup(props) {
+        const text = Utils.getTexts('home-prosas-notices');
+        const global = useGlobalState();
+        return { text, global };
     },
 
     props: {
@@ -20,7 +45,6 @@ app.component('home-prosas-notices', {
             type: String,
             required: true
         },
-        
         idList: {
             type: String
         }

--- a/components/main-footer/template.php
+++ b/components/main-footer/template.php
@@ -129,6 +129,8 @@ $entities = [
         <p>
             <strong><?php i::_e('Versão Beta') ?></strong>
             <?php i::_e('Você está em uma versão de teste da plataforma. Se encontrar qualquer divergência ou tiver dúvidas, entre em contato com o suporte.') ?>
+            <br/>
+            <?php i::_e('Desenvolvido por Laboratório do Futuro da Universidade Federal do Ceará.') ?>
         </p>
     </div>
 </div>

--- a/layouts/parts/main-header.php
+++ b/layouts/parts/main-header.php
@@ -31,15 +31,15 @@ $this->import('
             <template #default>
                 <?php $this->applyTemplateHook('mc-header-menu', 'begin') ?>
                 <!-- TODO: DESIGN PENDENTE -> Redirecionar para a nova tela de agenda -->
-                <?php $this->applyTemplateHook('mc-header-menu-home', 'before') ?>
-                <li>
-                    <?php $this->applyTemplateHook('mc-header-menu-home', 'begin') ?>
-                    <a href="<?= $app->createUrl('site', 'index') ?>" class="mc-header-menu--item home">
+                <?php $this->applyTemplateHook('mc-header-menu-events', 'before') ?>
+                <li v-if="global.enabledEntities.events">
+                    <?php $this->applyTemplateHook('mc-header-menu-events', 'begin') ?>
+                    <a href="<?= $app->createUrl('search', 'events') ?>" class="mc-header-menu--item event">
                         <p class="label"> <?php i::_e('Agenda') ?> </p>
                     </a>
-                    <?php $this->applyTemplateHook('mc-header-menu-home', 'end') ?>
+                    <?php $this->applyTemplateHook('mc-header-menu-events', 'end') ?>
                 </li>
-                <?php $this->applyTemplateHook('mc-header-menu-home', 'after') ?>
+                <?php $this->applyTemplateHook('mc-header-menu-events', 'after') ?>
 
                 <?php $this->applyTemplateHook('mc-header-menu-opportunity', 'before') ?>
                 <li v-if="global.enabledEntities.opportunities">
@@ -69,15 +69,6 @@ $this->import('
                     <?php $this->applyTemplateHook('mc-header-menu-spaces', 'end') ?>
                 </li>
                 <?php $this->applyTemplateHook('mc-header-menu-spaces', 'after') ?>
-                <?php $this->applyTemplateHook('mc-header-menu-events', 'before') ?>
-                <li v-if="global.enabledEntities.events">
-                    <?php $this->applyTemplateHook('mc-header-menu-events', 'begin') ?>
-                    <a href="<?= $app->createUrl('search', 'events') ?>" class="mc-header-menu--item event">
-                        <p class="label"> <?php i::_e('Eventos') ?> </p>
-                    </a>
-                    <?php $this->applyTemplateHook('mc-header-menu-events', 'end') ?>
-                </li>
-                <?php $this->applyTemplateHook('mc-header-menu-events', 'after') ?>
                 <!-- TODO: DESIGN PENDENTE -> Redirecionar para a nova tela de circuitos -->
                 <?php $this->applyTemplateHook('mc-header-menu-spaces', 'before') ?>
                 <li v-if="global.enabledEntities.spaces">

--- a/views/site/index.php
+++ b/views/site/index.php
@@ -17,7 +17,7 @@ $this->import('
 <home-header></home-header>
 <home-description></home-description>
 <home-entities></home-entities>
-<home-circuits></home-circuits>
-<home-prosas-notices client-id="lsf6jeu7-Wk04P2iSYMdcMhPZUNZqabK8CG6mAfRQ6M" id-list="13726,15300,15543,15338,13901,15191,15860,15861,15862,15863,15864, 15287"></home-prosas-notices>
-<home-register></home-register>
 <home-map></home-map>
+<home-register></home-register>
+<home-prosas-notices client-id="lsf6jeu7-Wk04P2iSYMdcMhPZUNZqabK8CG6mAfRQ6M" id-list="13726,15300,15543,15338,13901,15191,15860,15861,15862,15863,15864, 15287"></home-prosas-notices>
+<home-circuits></home-circuits>


### PR DESCRIPTION
## Contexto da issue

### Ajustes gerais

- [x] **Ajustar a ordem das seções** exibidas na Home, respeitando o layout aprovado

### Alterações específicas

#### Menu superior

- [x] Remover o item **"Eventos"** do menu principal
- [x] O item **"Agenda"** deve direcionar para a tela atual de eventos  (agenda)

#### Cards e blocos

- [x] **Remover o card de eventos** da lista de cards da Home
- [x] **Remover completamente a seção de Eventos** (não deve aparecer nem no conteúdo principal)
- [x] Alterar o texto do rodapé de seções de “Desenvolvido por” para **“Seção exibida por”** Prosas.

#### Menu lateral (mobile ou ancoragem)

- [x] Adaptar a **ordem das seções exibidas via menu** para refletir a estrutura do protótipo

#### Rodape 

- [x] Incluir a informação no rodapé: Desenvolvido por Laboratório do Futuro da universidade federal do Ceará

---

## Escopo DEV

- [x] Refatorar o componente de menu superior (remoção e redirecionamento)
- [x] Atualizar lista de cards da Home conforme os elementos definidos
- [x] Ajustar labels, textos e rodapés das seções
- [x] Adaptar o menu lateral (ou de ancoragem) para seguir a nova ordem das seções
- [x] Alterar o texto do rodapé de seções de “Desenvolvido por” para **“Seção exibida por”** Prosas.
- [x] Incluir a informação no rodapé: Desenvolvido por Laboratório do Futuro da universidade federal do Ceará.

---

## Evidências
[desktop.pdf](https://github.com/user-attachments/files/21496244/desktop.pdf)
[mobile.pdf](https://github.com/user-attachments/files/21496245/mobile.pdf)

