### PR TITLE
FEAT: new style for create event modal

### DIFF
--- a/components/create-event/README.md
+++ b/components/create-event/README.md
@@ -1,0 +1,30 @@
+# Componente `<create-event>`
+
+O componente `create-event` é utilizado para criar e gerenciar eventos. Ele exibe um formulário para criação e edição de eventos, incluindo campos obrigatórios e opcionais.
+
+### Eventos
+- **create** - Emitido após a criação ou atualização do evento.
+
+## Propriedades
+- *Boolean **editable*** - Define se o evento pode ser editado.
+
+## Slots
+- **default**: Conteúdo padrão do modal, exibido tanto na criação quanto na edição do evento.
+- **button**: Slot para personalizar o botão principal do modal.
+- **actions**: Ações exibidas no rodapé do modal, variando conforme o estado da entidade do evento (novo, rascunho, publicado).
+
+### Importando componente
+```PHP
+<?php 
+$this->import('create-event');
+?>
+```
+
+### Exemplos de uso
+```HTML
+<create-event :editable="true" @create="handleCreateEvent">
+    <template #button="{ modal }">
+        <button class="custom-button" @click="modal.close()">Custom Button</button>
+    </template>
+</create-event>
+```

--- a/components/create-event/script.js
+++ b/components/create-event/script.js
@@ -1,0 +1,104 @@
+app.component('create-event', {
+    template: $TEMPLATES['create-event'],
+    emits: ['create'],
+
+    setup() {
+        // os textos estão localizados no arquivo texts.php deste componente 
+        const text = Utils.getTexts('create-event')
+        return { text }
+    },
+
+    created() {
+        this.iterationFields();
+        var stat = 'publish';
+    },
+
+    data() {
+        return {
+            entity: null,
+            fields: [],
+        }
+    },
+
+    props: {
+        editable: {
+            type: Boolean,
+            default: true
+        },
+    },
+
+    computed: {
+        linguagemErrors() {
+            return this.entity.__validationErrors['term-linguagem'];
+        },
+        linguagemClasses() {
+            return this.linguagemErrors ? 'field error' : 'field';
+        },
+        modalTitle() {
+            if (this.entity?.id) {
+                if (this.entity.status == 1) {
+                    return __('eventoCriado', 'create-event');
+                } else {
+                    return __('criarRascunho', 'create-event');
+                }
+            } else {
+                return __('criarEvento', 'create-event');
+
+            }
+        },
+    },
+
+    methods: {
+        iterationFields() {
+            let skip = [
+                'createTimestamp',
+                'id',
+                'location',
+                'name',
+                'shortDescription',
+                'status',
+                'type',
+                '_type',
+                'userId',
+            ];
+            Object.keys($DESCRIPTIONS.event).forEach((item) => {
+                if (!skip.includes(item) && $DESCRIPTIONS.event[item].required) {
+                    this.fields.push(item);
+                }
+            })
+        },
+        createEntity() {
+            this.entity = Vue.ref(new Entity('event'));
+            this.entity.type = 1;
+            this.entity.terms = { linguagem: [] }
+
+        },
+        createDraft(modal) {
+            this.entity.status = 0;
+            this.save(modal);
+        },
+        createPublic(modal) {
+            //lançar dois eventos
+
+            this.entity.status = 1;
+            this.save(modal);
+        },
+        save(modal) {
+            modal.loading(true);
+
+            this.entity.save().then((response) => {
+                console.log(response);
+                this.$emit('create', response)
+                modal.loading(false);
+                Utils.pushEntityToList(this.entity);
+            }).catch((e) => {
+                modal.loading(false);
+            });
+        },
+
+
+        destroyEntity() {
+            setTimeout(() => this.entity = null, 200);
+        },
+    },
+});

--- a/components/create-event/template.php
+++ b/components/create-event/template.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * @var MapasCulturais\App $app
+ * @var MapasCulturais\Themes\BaseV2\Theme $this
+ */
+
+use MapasCulturais\i;
+
+$this->import('
+    entity-occurrence-list
+    entity-field 
+    entity-terms
+    mc-link
+    mc-modal 
+    create-occurrence
+');
+?>
+<mc-modal :title="modalTitle" classes="create-modal create-event-modal" button-label="<?php i::_e('Criar Evento')?>"  @open="createEntity()" @close="destroyEntity()">
+     <template v-if="entity && !entity.id" #default>
+         <label id="title"><?php i::_e('Crie um evento com informações básicas') ?><br><?php i::_e('e de forma rápida') ?></label>
+         <div class="create-modal__fields">
+             <entity-field :entity="entity" hide-required label=<?php i::esc_attr_e("Nome ou título") ?> prop="name"></entity-field>
+             <entity-terms :entity="entity" hide-required :editable="true" :classes="linguagemClasses" taxonomy='linguagem' title="<?php i::esc_attr_e("Linguagem cultural") ?>"></entity-terms>
+             <entity-field :entity="entity" hide-required prop="shortDescription" :max-length="400" label="<?php i::esc_attr_e("Adicione uma Descrição curta para o Evento") ?>"></entity-field>
+             <entity-field :entity="entity" hide-required v-for="field in fields" :prop="field"></entity-field>
+         </div>
+     </template>
+
+     <template v-if="entity?.id" #default>
+        <div>
+            <label><?php i::_e('É possível adicionar outras ocorrências para seu evento. Deseja inserir agora?'); ?> </label><br><br>
+            <!-- <label><?php i::_e('Para completar e publicar seu novo evento, acesse a área <b>Rascunhos</b> em <b>Meus Eventos</b> no <b>Painel de Controle</b>.  ');?></label> -->
+        </div>
+        <!-- <hr><br> -->
+         <!-- <entity-occurrence-list :entity="entity" editable create-event></entity-occurrence-list> -->
+         <create-occurrence :entity="entity" @create="addToOccurrenceList($event)"></create-occurrence>
+     </template>
+
+     <template #button="modal">
+         <slot :modal="modal"></slot>
+     </template>
+
+     <template v-if="!entity?.id" #actions="modal">
+         <button href="#title" class="button button--primary" @click="createPublic(modal)"><?php i::_e('Criar e Publicar') ?></button>
+         <button href="#title" class="button button--solid-dark" @click="createDraft(modal)"><?php i::_e('Criar em Rascunho') ?></button>
+         <button class="button button--text button--text-del " @click="modal.close()"><?php i::_e('Cancelar') ?></button>
+     </template>
+    <template v-if="entity?.id && entity.status==1" #actions="modal">
+        <div style="display: flex; justify-content: flex-start; gap: 8px; width: 100%;">
+            <mc-link :entity="entity" class="button button--primary-outline button--icon">
+            <?php i::_e('Ver Evento');?>
+            </mc-link>
+            <mc-link :entity="entity" route="edit" class="button button--primary button--icon">
+            <?php i::_e('Completar Informações')?>
+            </mc-link>
+        </div>
+    </template>
+    <template v-if="entity?.id && entity.status==0" #actions="modal">
+        <div style="display: flex; justify-content: flex-start; gap: 8px; width: 100%;">
+            <a href="/meus-eventos/#draft" class="button button--primary-outline button--icon">
+            <?php i::_e('Ver Rascunhos');?>
+            </a>
+            <mc-link :entity="entity" route="edit" class="button button--primary button--icon">
+            <?php i::_e('Completar Informações')?>
+            </mc-link>
+        </div>
+    </template>
+ </mc-modal>

--- a/components/create-event/texts.php
+++ b/components/create-event/texts.php
@@ -1,0 +1,8 @@
+<?php
+use MapasCulturais\i;
+
+return [
+    'eventoCriado' => i::__('Seu evento foi publicado!'),
+    'criarEvento' => i::__('Criar Evento'),
+    'criarRascunho' => i::__('Seu evento foi salvo como rascunho! Você pode acessá-lo em Meus eventos no Painel de controle.')
+];


### PR DESCRIPTION
🎯 Objetivo
--
Este PR atualiza a estrutura do modal de eventos para alinhar-se às novas diretrizes de design, garantindo consistência visual e melhor usabilidade.

📸 Captura de tela da correção
--
As principais mudanças incluem:

Realinhamento dos botões de ação para a esquerda, mantendo-os lado a lado.

Ajuste da disposição condicional dos botões conforme o status do evento (publicado ou rascunho).

Adequação visual do modal de acordo com o layout proposto pelo time de design.

Evidências:
<img width="1083" height="476" alt="image" src="https://github.com/user-attachments/assets/c0e237e6-96bb-4da8-8f1b-a141b5267525" />

<img width="1059" height="506" alt="image" src="https://github.com/user-attachments/assets/420feb94-4704-402b-aae9-dfb7d66e1e5b" />

https://github.com/user-attachments/assets/41c52794-31f6-482e-b947-9f365a08edce


