### PR TITLE
fix: concordância para a palavra iniciativa

### DIFF
--- a/translations/replacements
+++ b/translations/replacements
@@ -7,4 +7,7 @@ projeto >>> iniciativa
 home >>> início
 Trocar iniciativa vinculado ao evento >>> Trocar projeto vinculado à iniciativa
 Selecione um iniciativa a ser vinculado ao evento >>> Selecione uma iniciativa a ser vinculada ao evento
-Vincular a um iniciativa >> Vincular a uma iniciativa
+do iniciativa >>> da iniciativa
+um iniciativa >>> uma iniciativa
+este iniciativa >>> esta iniciativa
+você você >>> você


### PR DESCRIPTION
<img width="1315" height="884" alt="image" src="https://github.com/user-attachments/assets/54082d62-9195-4784-9538-df5310db7abb" />

- Foi ajustado de uma forma que acredito que vá ajustar em todos os locais sem ter que se preocupar muito com as outras possíveis traduções

No lugar de termos: 
- Vincular a um iniciativa >>> Vincular a uma iniciativa
- Adicionar a um iniciativa >>> Adicionar a uma iniciativa

podemos deixar genêrico somente as concordâncias:

do iniciativa >>> da iniciativa
um iniciativa >>> uma iniciativa
este iniciativa >>> esta iniciativa